### PR TITLE
Add RGB color box component with persistent color state using localStorage

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -52,6 +52,7 @@ import Navigator from "./components/file-7(API)/navigator";
 import FormValidation from "./components/file-8(validations)/formValidation";
 import FormValidationUASBased from "./components/file-8(validations)/formValidation(UAS based)";
 import LazyLoading from "./components/lazyLoading/loading";
+import RGBbox from "./components/Storage/localStorageMiniPrj";
 import PrintAPI from "./components/use-API/use-API";
 
 
@@ -102,8 +103,9 @@ function App(){
         <FormValidation/>
         <FormValidationUASBased/>
         <UseReduceForm/>
-        <LazyLoading/>*/}
-        <PrintAPI/>
+        <LazyLoading/>
+        <PrintAPI/>*/}
+        <RGBbox/>
           
       </>
     )

--- a/src/components/Storage/localStorageMiniPrj.jsx
+++ b/src/components/Storage/localStorageMiniPrj.jsx
@@ -1,0 +1,18 @@
+import { useState } from "react"
+
+export default function RGBbox(){
+    const colors = JSON.parse(localStorage.getItem('colors'));
+    const [r, setR] = useState(colors && colors?colors.r:0);
+    const [g, setG] = useState(colors && colors?colors.g:0);
+    const [b, setB] = useState(colors && colors?colors.b:0);
+    function saveColors(){
+        localStorage.setItem('colors', JSON.stringify({r, g, b}));
+    }
+    return(<>
+        <div style={{background:'rgb('+r+','+g+','+b+')' ,width:'30vw', height:'30vh', border:'1px solid black'}}></div>
+        <input type="range" value={r} onChange={(e)=>setR(e.target.value)} name="red" min={0} max={255} /><br />
+        <input type="range" value={g} onChange={(e)=>setG(e.target.value)} name="green" min={0} max={255} /><br />
+        <input type="range" value={b} onChange={(e)=>setB(e.target.value)} name="blue" min={0} max={255} /><br />
+        <button onClick={saveColors}>SAVE</button>
+    </>)
+}


### PR DESCRIPTION
This feature introduces a simple RGB color picker component that allows users to control the red, green, and blue values using range sliders. The selected color is displayed in a preview box and persisted in the browser using localStorage.
Key highlights:

- Range sliders for R, G, B channels
- Real-time color preview
- localStorage integration for saving color settings
- Defaults to saved values on component load
- This is a prototype for practicing local storage-based state persistence in React.